### PR TITLE
limit notification strings length

### DIFF
--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -157,6 +157,7 @@ public:
 
     static QStringList PUSHURL_WHITELIST;
     static const uint32_t NGC_GROUPNUM_OFFSET = 1000000000;
+    static const uint32_t NOTIFICATION_MAX_STR_LEN = 100;
 
 public:
     explicit Settings(IMessageBoxManager& messageBoxManager);

--- a/src/platform/desktop_notifications/desktopnotify.cpp
+++ b/src/platform/desktop_notifications/desktopnotify.cpp
@@ -59,8 +59,8 @@ void DesktopNotify::notifyMessage(const NotificationData& notificationData)
     }
 
     auto icon = notificationData.pixmap.isNull() ? snoreIcon : Snore::Icon(notificationData.pixmap);
-    auto title_sanitized = sanitizeTextForNotifications(notificationData.title);
-    auto message_sanitizied = sanitizeTextForNotifications(notificationData.message);
+    auto title_sanitized = sanitizeTextForNotifications(notificationData.title).left(Settings::NOTIFICATION_MAX_STR_LEN);
+    auto message_sanitizied = sanitizeTextForNotifications(notificationData.message).left(Settings::NOTIFICATION_MAX_STR_LEN);
     auto newNotification = Snore::Notification{snoreApp, Snore::Alert(), title_sanitized, message_sanitizied, icon, 0};
     latestId = newNotification.id();
 


### PR DESCRIPTION
i am not sure just sanitizing notification strings is enough to be really safe. maybe the bug was caused by a very long text and the buffer in SnoreToast.exe is too small.